### PR TITLE
Pdf d4s

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.idea
+docs
+
+**/node_modules
+**/dist
+**/bin
+**/coverage
+**/.DS_Store
+
+src/data
+web/.vite
+web/npm-debug.log*

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,7 +3,7 @@ name: Build and Publish Docker Image
 on:
   push:
     branches:
-      - main
+      - "**"
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,54 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nzagler/paperlink
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm AS web-build
+FROM node:22.12-bookworm AS web-build
 WORKDIR /src/web
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -36,7 +36,6 @@ RUN cd /src/integrations/digi4school && CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go
 
 FROM debian:bookworm-slim
 
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
     librsvg2-bin \
     ghostscript \
@@ -49,12 +48,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY --from=web-build /src/web/dist /app/dist
-
 COPY --from=go-build /src/app /app/app
-
 COPY --from=go-build /src/integrations/d4s /app/d4s
 COPY --from=go-build /src/integrations/d4s /app/integrations/d4s
-RUN ls -lah /app/
 RUN mkdir -p /app/data
+
+EXPOSE 8080
+VOLUME ["/app/data"]
 
 ENTRYPOINT ["/app/app"]

--- a/README.md
+++ b/README.md
@@ -42,3 +42,23 @@ The platform is built for self-hosting.
 
 Paperlink is released under the **GPL-3.0 License**.  
 
+## Docker
+
+Build the image from the repository root:
+
+```bash
+docker build -t paperlink:latest .
+```
+
+Run it with a persistent data volume:
+
+```bash
+docker run -d --name paperlink -p 8080:8080 -v paperlink-data:/app/data paperlink:latest
+```
+
+Or use Docker Compose:
+
+```bash
+docker compose up --build -d
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  paperlink:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: paperlink:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - paperlink-data:/app/data
+    restart: unless-stopped
+
+volumes:
+  paperlink-data:

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1134,8 +1134,6 @@ var SwaggerInfo = &swag.Spec{
 	Description:      "",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
-	LeftDelim:        "{{",
-	RightDelim:       "}}",
 }
 
 func init() {

--- a/src/ptf/writer.go
+++ b/src/ptf/writer.go
@@ -3,15 +3,17 @@ package ptf
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/pdfcpu/pdfcpu/pkg/api"
 	"io"
 	"os"
 	"os/exec"
+	"paperlink/pvf"
 	"paperlink/util"
 	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/pdfcpu/pdfcpu/pkg/api"
 )
 
 var log = util.GroupLog("PTF")
@@ -60,6 +62,124 @@ func WriteThumbnailPTFFromPDF(inputFile string) (string, error) {
 
 	outputFilePath := fmt.Sprintf("%s/output_thumb.ptf", tempDir)
 	if err := writePTFByPagePaths(pagePaths, outputFilePath); err != nil {
+		return "", err
+	}
+	return outputFilePath, nil
+}
+
+func WriteThumbnailPTFFromPVF(inputFile string) (string, error) {
+	metadata, err := pvf.ReadMetadata(inputFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read pvf metadata: %w", err)
+	}
+	if metadata.PageCount == 0 {
+		return "", fmt.Errorf("pvf has no pages")
+	}
+
+	tempDir, err := os.MkdirTemp(os.TempDir(), "pvf_thumb_*")
+	if err != nil {
+		return "", fmt.Errorf("could not create temporary directory: %w", err)
+	}
+
+	pageCount := int(metadata.PageCount)
+
+	pagePDFPaths := make([]string, pageCount)
+	pvfFile, err := os.Open(inputFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to open pvf file: %w", err)
+	}
+	for i := 0; i < pageCount; i++ {
+		idx := metadata.Indexes[i]
+		data := make([]byte, idx.Size)
+		n, readErr := pvfFile.ReadAt(data, int64(idx.Offset))
+		if readErr != nil || n != int(idx.Size) {
+			_ = pvfFile.Close()
+			return "", fmt.Errorf("failed to read pvf page %d: %w", i+1, readErr)
+		}
+		pagePath := filepath.Join(tempDir, fmt.Sprintf("page_%05d.pdf", i+1))
+		if writeErr := os.WriteFile(pagePath, data, 0o644); writeErr != nil {
+			_ = pvfFile.Close()
+			return "", fmt.Errorf("failed to write temp pdf for page %d: %w", i+1, writeErr)
+		}
+		pagePDFPaths[i] = pagePath
+	}
+	_ = pvfFile.Close()
+
+	type pvfThumbJob struct {
+		pageNum   int
+		pdfPath   string
+		thumbPath string
+	}
+
+	jobs := make([]pvfThumbJob, pageCount)
+	for i, pdfPath := range pagePDFPaths {
+		jobs[i] = pvfThumbJob{
+			pageNum:   i + 1,
+			pdfPath:   pdfPath,
+			thumbPath: filepath.Join(tempDir, fmt.Sprintf("thumb_%05d.png", i+1)),
+		}
+	}
+
+	workerCount := thumbnailWorkerCount
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	if workerCount > pageCount {
+		workerCount = pageCount
+	}
+
+	jobCh := make(chan pvfThumbJob, pageCount)
+	for _, j := range jobs {
+		jobCh <- j
+	}
+	close(jobCh)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, workerCount)
+	for w := 0; w < workerCount; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobCh {
+				cmd := exec.Command(
+					"gs",
+					"-sDEVICE=pnggray",
+					"-r100",
+					"-dDownScaleFactor=4",
+					"-dTextAlphaBits=4",
+					"-dGraphicsAlphaBits=4",
+					"-dBATCH",
+					"-dNOPAUSE",
+					"-sOutputFile="+j.thumbPath,
+					j.pdfPath,
+				)
+				if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
+					errCh <- fmt.Errorf("ghostscript failed for pvf page %d: %w: %s", j.pageNum, cmdErr, strings.TrimSpace(string(out)))
+					return
+				}
+				_ = os.Remove(j.pdfPath)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return "", err
+		}
+	}
+
+	thumbPaths := make([]string, pageCount)
+	for i, j := range jobs {
+		thumbPaths[i] = j.thumbPath
+	}
+	if len(thumbPaths) != pageCount {
+		return "", fmt.Errorf("thumbnail page count mismatch: expected=%d got=%d", pageCount, len(thumbPaths))
+	}
+
+	outputFilePath := filepath.Join(tempDir, "output_thumb.ptf")
+	if err := writePTFByPagePaths(thumbPaths, outputFilePath); err != nil {
 		return "", err
 	}
 	return outputFilePath, nil

--- a/src/scripts/brotli-dist.sh
+++ b/src/scripts/brotli-dist.sh
@@ -9,6 +9,11 @@ if ! command -v brotli >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v gzip >/dev/null 2>&1; then
+  echo "gzip is required but was not found in PATH" >&2
+  exit 1
+fi
+
 if [[ ! -d "$target_dir" ]]; then
   echo "Directory not found: $target_dir" >&2
   exit 1
@@ -53,26 +58,33 @@ print_summary_line() {
 }
 
 total_before=0
-total_after=0
+total_br_after=0
+total_gz_after=0
 file_count=0
 
 while IFS= read -r -d '' file; do
   before_size="$(stat -c %s "$file")"
-  temp_file="$(mktemp)"
 
-  brotli --force --quality=11 --output="$temp_file" "$file"
-  mv "$temp_file" "$file"
+  # Brotli sidecar (.br) — original file is kept untouched
+  brotli --force --quality=11 --output="${file}.br" "$file"
+  br_size="$(stat -c %s "${file}.br")"
 
-  after_size="$(stat -c %s "$file")"
+  # Gzip sidecar (.gz) — keep original, no timestamp in header
+  gzip --best --keep --force --no-name "$file"
+  gz_size="$(stat -c %s "${file}.gz")"
 
   total_before=$((total_before + before_size))
-  total_after=$((total_after + after_size))
+  total_br_after=$((total_br_after + br_size))
+  total_gz_after=$((total_gz_after + gz_size))
   file_count=$((file_count + 1))
 
-  print_summary_line "$file" "$before_size" "$after_size"
+  printf '%s (%s)\n' "$file" "$(format_bytes "$before_size")"
+  printf '  br:   '; print_summary_line "  " "$before_size" "$br_size"
+  printf '  gz:   '; print_summary_line "  " "$before_size" "$gz_size"
 done < <(
   find "$target_dir" -type f \
     \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' \) \
+    ! -iname '*.br' ! -iname '*.gz' \
     -print0 | sort -z
 )
 
@@ -83,4 +95,6 @@ fi
 
 echo
 echo "Processed $file_count files"
-print_summary_line "Total" "$total_before" "$total_after"
+printf 'Total plain: %s\n' "$(format_bytes "$total_before")"
+printf 'Total br:    '; print_summary_line "Total" "$total_before" "$total_br_after"
+printf 'Total gz:    '; print_summary_line "Total" "$total_before" "$total_gz_after"

--- a/src/server/routes/d4s/get_thumbnail.go
+++ b/src/server/routes/d4s/get_thumbnail.go
@@ -6,11 +6,13 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"paperlink/db/repo"
+	"paperlink/pvf"
 
 	"github.com/gin-gonic/gin"
 )
@@ -35,6 +37,21 @@ func ensureD4SThumbnail(uuid string, pdfPath string) (string, error) {
 		return "", err
 	}
 
+	// PVF files are not PDF — extract page 1 to a temp PDF for Ghostscript.
+	gsInput := pdfPath
+	if filepath.Ext(pdfPath) == ".pvf" {
+		pageData, err := pvf.ReadPage(pdfPath, 1)
+		if err != nil {
+			return "", fmt.Errorf("failed to read page 1 from pvf: %w", err)
+		}
+		tmpPDFPath := fmt.Sprintf("%s.%d.tmp.pdf", thumbPath, time.Now().UnixNano())
+		if err := os.WriteFile(tmpPDFPath, pageData, 0o644); err != nil {
+			return "", fmt.Errorf("failed to write temp pdf from pvf: %w", err)
+		}
+		defer os.Remove(tmpPDFPath)
+		gsInput = tmpPDFPath
+	}
+
 	stamp := time.Now().UnixNano()
 	tmpPNGPath := fmt.Sprintf("%s.%d.tmp.png", thumbPath, stamp)
 	tmpWebPPath := fmt.Sprintf("%s.%d.tmp.webp", thumbPath, stamp)
@@ -52,7 +69,7 @@ func ensureD4SThumbnail(uuid string, pdfPath string) (string, error) {
 		"-dBATCH",
 		"-dNOPAUSE",
 		"-sOutputFile="+tmpPNGPath,
-		pdfPath,
+		gsInput,
 	)
 	out, err := gsCmd.CombinedOutput()
 	if err != nil {
@@ -113,7 +130,7 @@ func GetThumbnail(c *gin.Context) {
 
 	thumbPath, err := ensureD4SThumbnail(book.FileUUID, file.Path)
 	if err != nil {
-		c.String(http.StatusInternalServerError, "failed to create thumbnail")
+		c.String(http.StatusInternalServerError, "failed to create thumbnail:"+err.Error())
 		return
 	}
 

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -22,16 +22,7 @@ import (
 
 var log = util.GroupLog("SERVER")
 
-func isBrotliCompressedAsset(path string) bool {
-	switch strings.ToLower(filepath.Ext(path)) {
-	case ".html", ".css", ".js":
-		return true
-	default:
-		return false
-	}
-}
-
-func isFrontendFile(path string) bool {
+func isCompressibleAsset(path string) bool {
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".html", ".css", ".js":
 		return true
@@ -48,12 +39,30 @@ func clientAcceptsBrotli(c *gin.Context) bool {
 	return strings.Contains(c.GetHeader("Accept-Encoding"), "br")
 }
 
-func serveFile(c *gin.Context, path string, allowBrotli bool) {
-	if allowBrotli && clientAcceptsBrotli(c) {
-		c.Header("Content-Encoding", "br")
-		c.Header("Content-Type", mime.TypeByExtension(filepath.Ext(path)))
-		c.File(path)
-		return
+func clientAcceptsGzip(c *gin.Context) bool {
+	return strings.Contains(c.GetHeader("Accept-Encoding"), "gzip")
+}
+
+func serveFile(c *gin.Context, path string, allowCompressed bool) {
+	c.Header("Vary", "Accept-Encoding")
+
+	if allowCompressed {
+		if clientAcceptsBrotli(c) {
+			if _, err := os.Stat(path + ".br"); err == nil {
+				c.Header("Content-Encoding", "br")
+				c.Header("Content-Type", mime.TypeByExtension(filepath.Ext(path)))
+				c.File(path + ".br")
+				return
+			}
+		}
+		if clientAcceptsGzip(c) {
+			if _, err := os.Stat(path + ".gz"); err == nil {
+				c.Header("Content-Encoding", "gzip")
+				c.Header("Content-Type", mime.TypeByExtension(filepath.Ext(path)))
+				c.File(path + ".gz")
+				return
+			}
+		}
 	}
 
 	c.Writer.Header().Del("Content-Encoding")
@@ -66,7 +75,7 @@ func Start() {
 	r.GET("/assets/*filepath", func(c *gin.Context) {
 		path := "./dist/assets" + c.Param("filepath")
 
-		serveFile(c, path, isBrotliCompressedAsset(path))
+		serveFile(c, path, isCompressibleAsset(path))
 	})
 	r.NoRoute(func(c *gin.Context) {
 		if strings.HasPrefix(c.Request.URL.Path, "/api") {
@@ -78,7 +87,7 @@ func Start() {
 		if filepath.Ext(requestPath) != "" {
 			path := frontendFilePath(requestPath)
 			if _, err := os.Stat(path); err == nil {
-				serveFile(c, path, isFrontendFile(path))
+				serveFile(c, path, isCompressibleAsset(path))
 				return
 			}
 

--- a/src/service/collabedit/annotation_store.go
+++ b/src/service/collabedit/annotation_store.go
@@ -23,7 +23,7 @@ var (
 	ErrAnnotationLockOwned    = errors.New("annotation lock owned by another client")
 )
 
-type annotationMessage struct {
+type AnnotationMessage struct {
 	ID        int                   `json:"id"`
 	Type      entity.AnnotationType `json:"type"`
 	Data      string                `json:"data"`
@@ -35,8 +35,8 @@ type annotationMessage struct {
 }
 
 type annotationActionPayload struct {
-	Previous *annotationMessage `json:"previous,omitempty"`
-	Current  *annotationMessage `json:"current,omitempty"`
+	Previous *AnnotationMessage `json:"previous,omitempty"`
+	Current  *AnnotationMessage `json:"current,omitempty"`
 }
 
 type annotationLockState struct {
@@ -158,7 +158,7 @@ func (s *AnnotationStore) MarkRoomInactive(documentUUID string) {
 	}
 }
 
-func (s *AnnotationStore) GetPageAnnotations(documentUUID string, page int64) ([]annotationMessage, error) {
+func (s *AnnotationStore) GetPageAnnotations(documentUUID string, page int64) ([]AnnotationMessage, error) {
 	if page <= 0 {
 		return nil, ErrInvalidAnnotation
 	}
@@ -173,7 +173,7 @@ func (s *AnnotationStore) GetPageAnnotations(documentUUID string, page int64) ([
 
 	state.LastTouchedAt = time.Now()
 
-	result := make([]annotationMessage, 0)
+	result := make([]AnnotationMessage, 0)
 	for _, annotation := range state.Annotations {
 		if annotation.Page != page {
 			continue
@@ -197,7 +197,7 @@ func (s *AnnotationStore) GetDocumentLocks(documentUUID string) ([]annotationLoc
 	return listAnnotationLocks(state), nil
 }
 
-func (s *AnnotationStore) CreateAnnotation(documentUUID string, input annotationMessage) (*annotationMessage, error) {
+func (s *AnnotationStore) CreateAnnotation(documentUUID string, input AnnotationMessage) (*AnnotationMessage, error) {
 	if err := validateAnnotationInput(input, true); err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func (s *AnnotationStore) CreateAnnotation(documentUUID string, input annotation
 	return &result, nil
 }
 
-func (s *AnnotationStore) UpdateAnnotation(documentUUID, ownerClientID string, input annotationMessage) (*annotationMessage, error) {
+func (s *AnnotationStore) UpdateAnnotation(documentUUID, ownerClientID string, input AnnotationMessage) (*AnnotationMessage, error) {
 	if input.ID == 0 {
 		return nil, ErrInvalidAnnotation
 	}
@@ -278,7 +278,7 @@ func (s *AnnotationStore) UpdateAnnotation(documentUUID, ownerClientID string, i
 	return &result, nil
 }
 
-func (s *AnnotationStore) MoveAnnotation(documentUUID, ownerClientID string, input annotationMessage) (*annotationMessage, error) {
+func (s *AnnotationStore) MoveAnnotation(documentUUID, ownerClientID string, input AnnotationMessage) (*AnnotationMessage, error) {
 	if input.ID == 0 || input.Page <= 0 {
 		return nil, ErrInvalidAnnotation
 	}
@@ -554,7 +554,7 @@ func (s *AnnotationStore) recordActionLocked(state *documentAnnotationState, act
 	})
 }
 
-func validateAnnotationInput(input annotationMessage, isCreate bool) error {
+func validateAnnotationInput(input AnnotationMessage, isCreate bool) error {
 	if input.Page <= 0 {
 		return fmt.Errorf("%w: page must be positive", ErrInvalidAnnotation)
 	}
@@ -583,7 +583,7 @@ func ensureAnnotationLockHeldLocked(state *documentAnnotationState, annotationID
 	return nil
 }
 
-func toAnnotationMessagePtr(annotation *entity.Annotation) *annotationMessage {
+func toAnnotationMessagePtr(annotation *entity.Annotation) *AnnotationMessage {
 	if annotation == nil {
 		return nil
 	}
@@ -591,8 +591,8 @@ func toAnnotationMessagePtr(annotation *entity.Annotation) *annotationMessage {
 	return &message
 }
 
-func toAnnotationMessage(annotation *entity.Annotation) annotationMessage {
-	return annotationMessage{
+func toAnnotationMessage(annotation *entity.Annotation) AnnotationMessage {
+	return AnnotationMessage{
 		ID:        annotation.ID,
 		Type:      annotation.Type,
 		Data:      annotation.Data,

--- a/src/service/collabedit/service.go
+++ b/src/service/collabedit/service.go
@@ -49,8 +49,8 @@ type outboundMessage struct {
 	User            *User                   `json:"user,omitempty"`
 	Users           []User                  `json:"users,omitempty"`
 	Page            *int64                  `json:"page,omitempty"`
-	Annotation      *annotationMessage      `json:"annotation,omitempty"`
-	Annotations     []annotationMessage     `json:"annotations,omitempty"`
+	Annotation      *AnnotationMessage      `json:"annotation,omitempty"`
+	Annotations     []AnnotationMessage     `json:"annotations,omitempty"`
 	AnnotationID    *int                    `json:"annotationId,omitempty"`
 	AnnotationLock  *annotationLockMessage  `json:"annotationLock,omitempty"`
 	AnnotationLocks []annotationLockMessage `json:"annotationLocks,omitempty"`
@@ -60,7 +60,7 @@ type outboundMessage struct {
 type inboundMessage struct {
 	Type         string             `json:"type"`
 	Page         *int64             `json:"page,omitempty"`
-	Annotation   *annotationMessage `json:"annotation,omitempty"`
+	Annotation   *AnnotationMessage `json:"annotation,omitempty"`
 	AnnotationID *int               `json:"annotationId,omitempty"`
 }
 

--- a/src/service/d4s/sync.go
+++ b/src/service/d4s/sync.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/uuid"
 	"os"
 	"os/exec"
 	"paperlink/db/entity"
@@ -20,6 +19,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func StartSyncTask(accs []entity.Digi4SchoolAccount) (string, error) {
@@ -300,6 +301,17 @@ func rescanForDBInsert(dir string, books []Book) error {
 				if err != nil {
 					return fmt.Errorf("failed to read metadata file %s: %v", fullPath, err)
 				}
+
+				thumbPTFFile, err := ptf.WriteThumbnailPTFFromPVF(fullPath)
+				if err != nil {
+					return fmt.Errorf("failed to generate thumbnail ptf file %s: %v", fullPath, err)
+				}
+				thumbDst := strings.TrimSuffix(fullPath, filepath.Ext(fullPath)) + "_thumb.ptf"
+				if err := util.CopyFile(thumbPTFFile, thumbDst); err != nil {
+					_ = os.RemoveAll(filepath.Dir(thumbPTFFile))
+					return fmt.Errorf("failed to store thumbnail ptf file %s: %v", thumbDst, err)
+				}
+				_ = os.RemoveAll(filepath.Dir(thumbPTFFile))
 
 				fd := entity.FileDocument{
 					UUID:  book.UUID,

--- a/web/src/composables/usePdfAnnotationOverlay.ts
+++ b/web/src/composables/usePdfAnnotationOverlay.ts
@@ -49,6 +49,54 @@ const DEFAULT_TEXTBOX_FONT_SIZE = 0.032
 const DEFAULT_DRAW_COLOR = '#ef4444'
 const DEFAULT_DRAW_STROKE_WIDTH = 0.004
 
+// Path is stored in normalized 0-1 coordinates. A tolerance of 0.001 equals
+// 0.1% of the page dimension — sub-pixel at any typical display size.
+const RDP_TOLERANCE = 0.001
+const COORD_PRECISION = 4
+
+function roundCoord(v: number): number {
+  const f = 10 ** COORD_PRECISION
+  return Math.round(v * f) / f
+}
+
+function pointToSegmentDistance(
+  px: number, py: number,
+  ax: number, ay: number,
+  bx: number, by: number,
+): number {
+  const dx = bx - ax
+  const dy = by - ay
+  const lenSq = dx * dx + dy * dy
+  if (lenSq === 0) {
+    const ex = px - ax, ey = py - ay
+    return Math.sqrt(ex * ex + ey * ey)
+  }
+  return Math.abs(dy * px - dx * py + bx * ay - by * ax) / Math.sqrt(lenSq)
+}
+
+// Ramer-Douglas-Peucker on an index slice. Returns the subset of indices to keep.
+function rdp(indices: number[], pts: Array<{ x: number; y: number }>, tolerance: number): number[] {
+  if (indices.length <= 2) return indices
+  const first = indices[0]
+  const last = indices[indices.length - 1]
+  const ax = pts[first].x, ay = pts[first].y
+  const bx = pts[last].x, by = pts[last].y
+
+  let maxDist = 0
+  let maxAt = 0
+  for (let i = 1; i < indices.length - 1; i++) {
+    const d = pointToSegmentDistance(pts[indices[i]].x, pts[indices[i]].y, ax, ay, bx, by)
+    if (d > maxDist) { maxDist = d; maxAt = i }
+  }
+
+  if (maxDist > tolerance) {
+    const left = rdp(indices.slice(0, maxAt + 1), pts, tolerance)
+    const right = rdp(indices.slice(maxAt), pts, tolerance)
+    return [...left.slice(0, -1), ...right]
+  }
+  return [first, last]
+}
+
 export function usePdfAnnotationOverlay({
   currentPage,
   pdfCanvasEl,
@@ -94,6 +142,8 @@ export function usePdfAnnotationOverlay({
   let suppressedSelectionLockSync = 0
   let activeSelectionLockId: number | null = null
   let unsubscribeCollabMessages: (() => void) | null = null
+  let textboxDebounceTimer: ReturnType<typeof setTimeout> | null = null
+  let pendingTextboxPersist: (() => void) | null = null
 
   function getOverlaySize() {
     const canvas = pdfCanvasEl.value
@@ -345,14 +395,34 @@ export function usePdfAnnotationOverlay({
   }
 
   function normalizeCanvasPath(path: CanvasPathCommand[], width: number, height: number) {
-    return path.map((command) => {
-      const normalized: CanvasPathCommand = [command[0]]
-      for (let index = 1; index < command.length; index += 1) {
-        const dimension = index % 2 === 1 ? width : height
-        normalized.push(dimension ? command[index] / dimension : 0)
+    // Step 1: normalize pixel coords → 0-1
+    const normalized = path.map((command) => {
+      const norm: CanvasPathCommand = [command[0]]
+      for (let i = 1; i < command.length; i++) {
+        const dim = i % 2 === 1 ? width : height
+        norm.push(dim ? command[i] / dim : 0)
       }
-      return normalized
+      return norm
     })
+
+    // Step 2: RDP simplification — use the endpoint of each command as the
+    // representative point. M is always kept; Q/L/C are filtered by RDP.
+    const pts = normalized.map((cmd) => {
+      const len = cmd.length
+      return len >= 3
+        ? { x: cmd[len - 2] as number, y: cmd[len - 1] as number }
+        : { x: cmd[1] as number ?? 0, y: cmd[2] as number ?? 0 }
+    })
+    const kept = new Set(rdp(normalized.map((_, i) => i), pts, RDP_TOLERANCE))
+
+    // Step 3: round to fixed precision
+    return normalized
+      .filter((cmd, i) => cmd[0] === 'M' || kept.has(i))
+      .map((cmd) => {
+        const rounded: CanvasPathCommand = [cmd[0]]
+        for (let i = 1; i < cmd.length; i++) rounded.push(roundCoord(cmd[i] as number))
+        return rounded
+      })
   }
 
   function applyPathAppearance(path: FabricPathWithId, annotation?: PDFCanvasAnnotation) {
@@ -393,6 +463,7 @@ export function usePdfAnnotationOverlay({
 
   function syncObjectInteractivity(object: FabricAnnotationObject) {
     const drawingMode = activeTool.value === 'draw'
+    const placingTextbox = activeTool.value === 'textbox'
     const annotationId = object.annotationId
     const lockedByOther = typeof annotationId === 'number' && isAnnotationLockedByOther(annotationId)
 
@@ -405,8 +476,8 @@ export function usePdfAnnotationOverlay({
     }
 
     object.set({
-      selectable: !drawingMode && !lockedByOther,
-      evented: !drawingMode && !lockedByOther,
+      selectable: !drawingMode && !placingTextbox && !lockedByOther,
+      evented: !drawingMode && !placingTextbox && !lockedByOther,
     })
 
     if (isTextboxObject(object)) {
@@ -578,6 +649,17 @@ export function usePdfAnnotationOverlay({
 
     const annotations = listPageAnnotations(page)
     const nextIDs = new Set(annotations.map((annotation) => annotation.id))
+
+    // Remove any pending objects that haven't received a server ID yet —
+    // they don't belong to the new page and aren't tracked in renderedObjects.
+    withSuppressedRemoveEvents(() => {
+      for (const object of fabricCanvas!.getObjects()) {
+        const obj = object as FabricAnnotationObject
+        if (obj.pendingCreate) {
+          fabricCanvas!.remove(object)
+        }
+      }
+    })
 
     for (const [annotationID, object] of Array.from(renderedObjects.entries())) {
       if (!nextIDs.has(annotationID)) {
@@ -758,13 +840,19 @@ export function usePdfAnnotationOverlay({
     if (!fabricCanvas) return
 
     const drawingMode = tool === 'draw'
+    const placingTextbox = tool === 'textbox'
     fabricCanvas.isDrawingMode = drawingMode
-    fabricCanvas.selection = !drawingMode
-    fabricCanvas.skipTargetFind = drawingMode
+    fabricCanvas.selection = !drawingMode && !placingTextbox
+    fabricCanvas.skipTargetFind = drawingMode || placingTextbox
 
-    if (drawingMode) {
+    if (drawingMode || placingTextbox) {
       fabricCanvas.discardActiveObject()
       selectedAnnotationId.value = null
+    }
+
+    const upperCanvasEl = (fabricCanvas as unknown as { upperCanvasEl?: HTMLCanvasElement }).upperCanvasEl
+    if (upperCanvasEl) {
+      upperCanvasEl.style.cursor = placingTextbox ? 'crosshair' : ''
     }
 
     for (const object of renderedObjects.values()) {
@@ -807,14 +895,19 @@ export function usePdfAnnotationOverlay({
     syncStyleControls()
   }
 
-  async function addTextbox() {
+  function addTextbox() {
+    if (!fabricCanvas || collabStatus.value !== 'connected') return
+    setActiveTool('textbox')
+  }
+
+  function placeTextboxAt(left: number, top: number) {
     if (!fabricCanvas || collabStatus.value !== 'connected') return
     if (!syncOverlaySize()) return
 
     const { width, height } = getOverlaySize()
     const textbox = new Textbox('Text', {
-      left: width * 0.16,
-      top: height * 0.14,
+      left,
+      top,
       width: width * 0.3,
       fontSize: Math.max(12, height * textboxDefaultFontSize),
       fill: textboxDefaultFill,
@@ -839,8 +932,8 @@ export function usePdfAnnotationOverlay({
       id: 0,
       page: currentPage.value,
       text: 'Text',
-      positionX: 0.16,
-      positionY: 0.14,
+      positionX: left / width,
+      positionY: top / height,
       width: 0.3,
       fontSize: textboxDefaultFontSize,
       fill: textboxDefaultFill,
@@ -865,6 +958,27 @@ export function usePdfAnnotationOverlay({
     }
 
     updateAnnotation(toCollabAnnotation(annotation))
+  }
+
+  function flushTextboxDebounce() {
+    if (textboxDebounceTimer !== null) {
+      clearTimeout(textboxDebounceTimer)
+      textboxDebounceTimer = null
+    }
+    if (pendingTextboxPersist) {
+      pendingTextboxPersist()
+      pendingTextboxPersist = null
+    }
+  }
+
+  function debouncePersistTextbox(object: FabricTextboxWithId) {
+    pendingTextboxPersist = () => persistTextbox(object)
+    if (textboxDebounceTimer !== null) clearTimeout(textboxDebounceTimer)
+    textboxDebounceTimer = setTimeout(() => {
+      textboxDebounceTimer = null
+      pendingTextboxPersist?.()
+      pendingTextboxPersist = null
+    }, 1000)
   }
 
   function persistCanvasObject(object: FabricPathWithId, mode: 'update' | 'move' = 'update') {
@@ -1101,6 +1215,8 @@ export function usePdfAnnotationOverlay({
             const pendingTextbox = findPendingTextbox()
             if (pendingTextbox) {
               applyAnnotationToTextbox(pendingTextbox, annotation)
+              renderedObjects.set(annotation.id, pendingTextbox)
+              annotationCount.value = fabricCanvas?.getObjects().length ?? annotationCount.value
               fabricCanvas?.requestRenderAll()
               syncLockOverlays()
               syncSelectionState()
@@ -1251,6 +1367,12 @@ export function usePdfAnnotationOverlay({
       upperCanvasEl.style.zIndex = '21'
     }
 
+    fabricCanvas.on('mouse:down', (event) => {
+      if (activeTool.value !== 'textbox') return
+      const pointer = fabricCanvas!.getScenePoint(event.e)
+      placeTextboxAt(pointer.x, pointer.y)
+    })
+
     fabricCanvas.on('object:modified', (event) => {
       if (!event.target) return
 
@@ -1298,7 +1420,7 @@ export function usePdfAnnotationOverlay({
     })
     fabricCanvas.on('text:changed', (event) => {
       if (!event.target || !isTextboxObject(event.target)) return
-      persistTextbox(event.target)
+      debouncePersistTextbox(event.target)
     })
     fabricCanvas.on('path:created', (event) => {
       if (!event.path || !isPathObject(event.path) || collabStatus.value !== 'connected') {
@@ -1319,8 +1441,8 @@ export function usePdfAnnotationOverlay({
       createAnnotation(toCollabAnnotation(serializeCanvasPath(event.path, width, height)))
     })
     fabricCanvas.on('selection:created', syncSelectionState)
-    fabricCanvas.on('selection:updated', syncSelectionState)
-    fabricCanvas.on('selection:cleared', syncSelectionState)
+    fabricCanvas.on('selection:updated', () => { flushTextboxDebounce(); syncSelectionState() })
+    fabricCanvas.on('selection:cleared', () => { flushTextboxDebounce(); syncSelectionState() })
 
     overlayReady.value = true
     setActiveTool('select')
@@ -1362,6 +1484,7 @@ export function usePdfAnnotationOverlay({
   })
 
   watch(currentPage, (page) => {
+    flushTextboxDebounce()
     if (activeSelectionLockId !== null) {
       releaseSelectionLock(activeSelectionLockId)
     }
@@ -1401,6 +1524,7 @@ export function usePdfAnnotationOverlay({
   })
 
   onBeforeUnmount(() => {
+    flushTextboxDebounce()
     if (resizeFrame) cancelAnimationFrame(resizeFrame)
     resizeObserver?.disconnect()
     resizeObserver = null

--- a/web/src/views/D4S.vue
+++ b/web/src/views/D4S.vue
@@ -7,6 +7,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 
+import { apiFetch } from "@/auth/api"
 import { listD4SBooks, takeD4SBook, type Digi4SchoolBook } from "@/lib/d4s_api"
 
 type Notice = { type: "success" | "error"; message: string } | null

--- a/web/src/views/PDFReader.vue
+++ b/web/src/views/PDFReader.vue
@@ -125,7 +125,24 @@
             {{ readerError }}
           </div>
 
-          <div v-else class="flex min-h-full w-full justify-center p-4 md:p-6">
+          <div v-else class="relative flex min-h-full w-full justify-center p-4 md:p-6">
+            <Transition
+              enter-active-class="transition-opacity duration-150"
+              leave-active-class="transition-opacity duration-150"
+              enter-from-class="opacity-0"
+              leave-to-class="opacity-0"
+            >
+              <div
+                v-if="activeTool === 'textbox'"
+                class="pointer-events-none absolute inset-x-0 top-6 z-30 flex justify-center"
+              >
+                <div class="flex items-center gap-2 rounded-full border border-neutral-300 bg-white/90 px-4 py-1.5 text-xs font-medium text-neutral-700 shadow-sm backdrop-blur-sm dark:border-neutral-600 dark:bg-neutral-900/90 dark:text-neutral-200">
+                  <Type class="h-3.5 w-3.5 shrink-0" />
+                  Click on the page to place · <kbd class="rounded bg-neutral-100 px-1.5 py-0.5 text-[10px] font-mono dark:bg-neutral-800">Esc</kbd> to cancel
+                </div>
+              </div>
+            </Transition>
+
             <div class="relative inline-block max-w-full">
               <canvas
                 ref="canvasEl"
@@ -152,8 +169,8 @@
             <div class="grid grid-cols-3 gap-2">
               <Button
                 variant="outline"
-                class="h-auto flex-col gap-1.5 px-3 py-3"
-                :class="activeTool === 'select' ? 'border-neutral-900 text-neutral-900 dark:border-neutral-100 dark:text-neutral-100' : ''"
+                class="h-auto flex-col gap-1.5 px-3 py-3 transition-colors"
+                :class="activeTool === 'select' ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-100 dark:bg-neutral-100 dark:text-neutral-900' : ''"
                 :disabled="!overlayReady || collabStatus !== 'connected'"
                 @click="setActiveTool('select')"
               >
@@ -162,8 +179,8 @@
               </Button>
               <Button
                 variant="outline"
-                class="h-auto flex-col gap-1.5 px-3 py-3"
-                :class="activeTool === 'textbox' ? 'border-neutral-900 text-neutral-900 dark:border-neutral-100 dark:text-neutral-100' : ''"
+                class="h-auto flex-col gap-1.5 px-3 py-3 transition-colors"
+                :class="activeTool === 'textbox' ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-100 dark:bg-neutral-100 dark:text-neutral-900' : ''"
                 :disabled="!overlayReady || collabStatus !== 'connected'"
                 @click="setActiveTool('textbox')"
               >
@@ -172,8 +189,8 @@
               </Button>
               <Button
                 variant="outline"
-                class="h-auto flex-col gap-1.5 px-3 py-3"
-                :class="activeTool === 'draw' ? 'border-neutral-900 text-neutral-900 dark:border-neutral-100 dark:text-neutral-100' : ''"
+                class="h-auto flex-col gap-1.5 px-3 py-3 transition-colors"
+                :class="activeTool === 'draw' ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-100 dark:bg-neutral-100 dark:text-neutral-900' : ''"
                 :disabled="!overlayReady || collabStatus !== 'connected'"
                 @click="setActiveTool('draw')"
               >
@@ -285,8 +302,15 @@
                     Text Box
                   </div>
                   <div class="mt-1 text-[11px] text-neutral-500 dark:text-neutral-400">
-                    Configure the next textbox, then place it on the page.
+                    Set the style below, then click anywhere on the PDF to place.
                   </div>
+                </div>
+                <div class="flex items-center gap-2 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-[11px] text-neutral-600 dark:border-neutral-700 dark:bg-neutral-800/60 dark:text-neutral-300">
+                  <span class="relative flex h-2 w-2 shrink-0">
+                    <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-neutral-400 opacity-75 dark:bg-neutral-500" />
+                    <span class="relative inline-flex h-2 w-2 rounded-full bg-neutral-500 dark:bg-neutral-400" />
+                  </span>
+                  Waiting for click on page…
                 </div>
                 <div class="space-y-2">
                   <div class="text-xs text-neutral-600 dark:text-neutral-300">Font color</div>
@@ -311,12 +335,11 @@
                   />
                 </div>
                 <Button
+                  variant="outline"
                   class="w-full justify-start"
-                  :disabled="!overlayReady || collabStatus !== 'connected'"
-                  @click="addTextbox"
+                  @click="setActiveTool('select')"
                 >
-                  <Type class="h-4 w-4" />
-                  Place text box
+                  Cancel
                 </Button>
               </template>
 
@@ -366,7 +389,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { usePdfAnnotationOverlay } from '@/composables/usePdfAnnotationOverlay'
 import { usePdfReader } from '@/composables/usePdfReader'
 import { Badge } from '@/components/ui/badge'
@@ -440,6 +463,15 @@ const {
 })
 
 const pageInput = ref('1')
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && activeTool.value === 'textbox') {
+    setActiveTool('select')
+  }
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown))
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 
 const isFirstPage = computed(() => currentPage.value <= 1)
 const isLastPage = computed(() => pageCount.value === 0 || currentPage.value >= pageCount.value)


### PR DESCRIPTION
PDFEditor: place text box on mouse click. When switching pages textboxes no longer are shown. Made the canvas data smaller. Dont send an textUpdate every keystroke instead debounce it for 1s and when unlock
d4s: create pdf thumbnails when importing d4s book. Fixed getThumbnail endpoint for the d4s page.
brotli-disk now creates gzip and plain version too for backwards compatibility